### PR TITLE
fix: prefer `types`/`typings` entries

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,6 +27,7 @@ describe('resolver', () => {
     'magic-string-ast',
     'magic-string',
     'fast-glob',
+    'hookable',
     '@babel/parser',
     'yargs',
     'debug',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR aims to fix the issue where `types`/`typings` entries are not prioritized.

### Help Needed

However, I've encountered a problem where `oxc-resolver` silently picks the `"default"` entry if it comes before the `conditionNames` or if no `conditionNames` match. This means I can't distinguish between whether `typesResolver` resolves with the expected `types`/`typings` condition entries or `"default"` entries. You can refer to the failed tests for examples: https://github.com/sxzz/dts-resolver/actions/runs/15519957704/job/43691822051?pr=4

This might require some changes upstream (`oxc-resolver`) to provide more information about the resolved result, or a config to enforce the `conditionNames`. WDYT? 🤔

### Linked Issues

resolves https://github.com/sxzz/dts-resolver/issues/3


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
